### PR TITLE
Re-add the functions for division and subtraction, faster than composite functions

### DIFF
--- a/arrayfuncs.go
+++ b/arrayfuncs.go
@@ -16,6 +16,16 @@ func divSlice(out, a, b []float64) {
 	}
 }
 
+// subSlice subtracts two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func subSlice(out, a, b []float64) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] - b[i]
+	}
+}
+
 // addSlice adds two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil

--- a/arrayfuncs_amd64.go
+++ b/arrayfuncs_amd64.go
@@ -35,6 +35,15 @@ func mulSliceGo(out, a, b []float64) {
 	}
 }
 
+// approx 3x faster than Go
+func subSlice(out, a, b []float64)
+
+func subSliceGo(out, a, b []float64) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] - b[i]
+	}
+}
+
 // approx 4x faster than Go
 func minSlice(out, a, b []float64)
 

--- a/arrayfuncs_amd64.s
+++ b/arrayfuncs_amd64.s
@@ -41,6 +41,46 @@ done_div:
     RET ,
 
 
+// func subSlice(out []float64, a []float64, b []float64) 
+TEXT ·subSlice(SB), 7, $0
+    MOVQ    out+0(FP),SI        // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len(out)
+    SHRQ    $2, DX              // DX: len(out) / 4
+    ANDQ    $3, R10             // R10: len(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_sub
+loopback_sub:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    SUBPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    SUBPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_sub
+remain_sub:
+    CMPQ    R10,$0
+    JEQ     done_sub
+onemore_sub:    
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    SUBSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_sub
+done_sub:
+    RET 
 
 // func mulSlice(out []float64, a []float64, b []float64) 
 TEXT ·mulSlice(SB), 7, $0
@@ -559,3 +599,4 @@ done_sum:
     ADDSD   X2, X0
     MOVSD   X0, ret+24(FP)
     RET ,
+

--- a/narray.go
+++ b/narray.go
@@ -255,6 +255,58 @@ func Mul(out *NArray, in ...*NArray) *NArray {
 	return out
 }
 
+// Div divides narrays elementwise.
+//   out = in[0] / in[1] / in[2] ....
+// Will panic if there are not at least two input narrays
+// or if narray shapes don't match.
+// If out is nil a new array is created.
+func Div(out *NArray, in ...*NArray) *NArray {
+
+	if len(in) < 2 {
+		panic("not in enough arguments")
+	}
+	if out == nil {
+		out = New(in[0].Shape...)
+	}
+	if !EqualShape(out, in...) {
+		panic("narrays must have equal shape.")
+	}
+
+	divSlice(out.Data, in[0].Data, in[1].Data)
+
+	// Multiply each following, if more than two arguments.
+	for k := 2; k < len(in); k++ {
+		divSlice(out.Data, out.Data, in[k].Data)
+	}
+	return out
+}
+
+// Sub subtracts narrays elementwise.
+//   out = in[0] - in[1] - in[2] ....
+// Will panic if there are not at least two input narrays
+// or if narray shapes don't match.
+// If out is nil a new array is created.
+func Sub(out *NArray, in ...*NArray) *NArray {
+
+	if len(in) < 2 {
+		panic("not in enough arguments")
+	}
+	if out == nil {
+		out = New(in[0].Shape...)
+	}
+	if !EqualShape(out, in...) {
+		panic("narrays must have equal shape.")
+	}
+
+	subSlice(out.Data, in[0].Data, in[1].Data)
+
+	// Multiply each following, if more than two arguments.
+	for k := 2; k < len(in); k++ {
+		subSlice(out.Data, out.Data, in[k].Data)
+	}
+	return out
+}
+
 // AddConst adds const to an narray elementwise.
 // out = in + c
 // If out is nil a new array is created.

--- a/narray_test.go
+++ b/narray_test.go
@@ -440,8 +440,7 @@ func TestAddScaled(t *testing.T) {
 
 func TestSub(t *testing.T) {
 
-	z := Scale(nil, randna[0], -1)
-	Add(z, randna[1], z)
+	z := Sub(nil, randna[1], randna[0])
 
 	xx := New(z.Shape...)
 	for k, v := range randna[0].Data {
@@ -454,8 +453,7 @@ func TestSub(t *testing.T) {
 
 func TestDiv(t *testing.T) {
 
-	z := Rcp(nil, randna[0])
-	Mul(z, randna[1], z)
+	z := Div(nil, randna[1], randna[0])
 
 	xx := New(z.Shape...)
 	for k, v := range randna[0].Data {
@@ -762,6 +760,40 @@ func BenchmarkAdd10001(b *testing.B) {
 	}
 }
 
+func BenchmarkSub10001(b *testing.B) {
+	N := 10001
+	na := New(N)
+	nb := New(N)
+	dst := New(N)
+	for i := 0; i < N; i++ {
+		na.Data[i] = float64(i)
+		nb.Data[i] = float64(i) * 0.5
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(N * 8))
+	for i := 0; i < b.N; i++ {
+		dst = Sub(dst, na, nb)
+	}
+}
+
+func BenchmarkSubScaleMul10001(b *testing.B) {
+	N := 10001
+	na := New(N)
+	nb := New(N)
+	dst := New(N)
+	for i := 0; i < N; i++ {
+		na.Data[i] = float64(i)
+		nb.Data[i] = float64(i) * 0.5
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(N * 8))
+	for i := 0; i < b.N; i++ {
+		dst = Add(dst, na, Scale(dst, nb, -1.0))
+	}
+}
+
 func BenchmarkMul10001(b *testing.B) {
 	N := 10001
 	na := New(N)
@@ -776,6 +808,40 @@ func BenchmarkMul10001(b *testing.B) {
 	b.SetBytes(int64(N * 8))
 	for i := 0; i < b.N; i++ {
 		dst = Mul(dst, na, nb)
+	}
+}
+
+func BenchmarkDiv10001(b *testing.B) {
+	N := 10001
+	na := New(N)
+	nb := New(N)
+	dst := New(N)
+	for i := 0; i < N; i++ {
+		na.Data[i] = float64(i)
+		nb.Data[i] = float64(i) * 0.5
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(N * 8))
+	for i := 0; i < b.N; i++ {
+		dst = Div(dst, na, nb)
+	}
+}
+
+func BenchmarkDivRcpMul10001(b *testing.B) {
+	N := 10001
+	na := New(N)
+	nb := New(N)
+	dst := New(N)
+	for i := 0; i < N; i++ {
+		na.Data[i] = float64(i)
+		nb.Data[i] = float64(i) * 0.5
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(N * 8))
+	for i := 0; i < b.N; i++ {
+		dst = Mul(dst, na, Rcp(dst, nb))
 	}
 }
 


### PR DESCRIPTION
I would consider re-adding division and subtraction. Subtraction is 50% faster, so even though they might seem superfluous, there is some speed to be gained on these very common operations.
## Subtraction:

```
BenchmarkSub10001                 300000              5053 ns/op        15831.81 MB/s
BenchmarkSubScaleMul10001         200000              7925 ns/op        10095.07 MB/s
```
## Division:

```
BenchmarkDiv10001          50000             34982 ns/op        2287.12 MB/s
BenchmarkDivRcpMul10001    50000             40462 ns/op        1977.35 MB/s
```
